### PR TITLE
Method path.existsSync is deprecated, now fs.existsSync should be used

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ fs = require( "fs" )
 
 keysPath = path.join( __dirname, "defaultKeys.json" )
 
-defaults = path.existsSync( keysPath )
+defaults = fs.existsSync( keysPath )
   ? JSON.parse( fs.readFileSync( keysPath ) )
   : undefined
 


### PR DESCRIPTION
Just as simple as that. Please apply and update module in npm registry.

Thanks.
