### PR TITLE
update to the new nodejs binary name

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.3",
   "description": "Key signing and verification for rotated credentials",
   "scripts": {
-    "install": "node ./install.js"
+    "install": "nodejs ./install.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The proper binary name for node.js has been "nodejs" for some time now. Using "node" fails on Debian/Ubuntu.
