### PR TITLE
Remove default key generation and associated expectations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,12 @@
 var crypto = require("crypto")
-  , path   = require("path")
-  , fs     = require("fs")
-
-  , existsSync = fs.existsSync || path.existsSync
-
-  , keysPath = path.join(__dirname, "defaultKeys.json")
-  , defaults = existsSync(keysPath)
-      ? JSON.parse(fs.readFileSync(keysPath))
-      : undefined
-
+  
 function Keygrip(keys, algorithm, encoding) {
   if (!algorithm) algorithm = "sha1";
   if (!encoding) encoding = "base64";
   if (!(this instanceof Keygrip)) return new Keygrip(keys, algorithm, encoding)
 
   if (!keys || !(0 in keys)) {
-    if (keys = defaults) console.warn("No keys specified, using defaults instead.")
-
-    else throw "Keys must be provided or default keys must exist."
+    throw "Keys must be provided."
   }
 
   function sign(data, key) {

--- a/install.js
+++ b/install.js
@@ -1,7 +1,0 @@
-require("fs").writeFileSync("./defaultKeys.json",
-  JSON.stringify([
-    Array(33).join("x").replace(/x/g, function() {
-      return (Math.random() * 16|0).toString(16)
-    })
- ])
-)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.4",
   "description": "Key signing and verification for rotated credentials",
   "scripts": {
-    "install": "[ -x /usr/bin/nodejs ] && /usr/bin/nodejs ./install.js || node ./install.js"
+    "test": "node test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -5,11 +5,13 @@ var assert = require("assert")
   , Keygrip = require("./")
   , keylist, keys, hash, index
 
-// keygrip takes an array of keys, but if none exist,
-// it uses the defaults created during npm installation.
-// (but it'll will warn you)
-console.log("Ignore this message:")
-keys = new Keygrip(/* empty list */)
+// keygrip takes an array of keys. If missing or empty, it will throw.
+assert.throws(function() {
+	keys = new Keygrip(/* empty list */);
+}, /must be provided/);
+
+// Randomly generated key - don't use this for something real. Don't be that person.
+keys = new Keygrip(['06ae66fdc6c2faf5a401b70e0bf885cb']);  
 
 // .sign returns the hash for the first key
 // all hashes are SHA1 HMACs in url-safe base64


### PR DESCRIPTION
Currently, the npm install process attempts to run install.js via node (or
nodejs if you're on debian) to generate a default set of keys. Rather than
try to make this work for all possible platform/shell combinations, remove
the install script and the logic that attempts to load default keys. Throw
if no keys are specified at initialization.

This is a breaking change for those relying on the old behaviour, but if
you're relying on keying material that lives under node_modules, it's time
to reevaluate your security processes anyway.

Note that tests are now executable via `npm test`... on every platform
except debian.  (Sorry about that.  ln -s is your friend.)
