### PR TITLE
Adjust usage message

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,5 +125,5 @@ Keygrip.sign =
 Keygrip.verify =
 Keygrip.index =
 Keygrip.indexOf = function() {
-  throw new Error("Usage: require('keygrip')(<array-of-keys>)")
+  throw new Error("Usage: require(\'keygrip\')(<array-of-keys>)")
 }


### PR DESCRIPTION
This change means that the dependency on `keygrip` won't be picked up by static analysis, which would help a lot for use in SystemJS.

I completely understand if this is not relevant to this project too.