### PR TITLE
Adding license info to the package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "keygrip",
   "version": "1.0.1",
   "description": "Key signing and verification for rotated credentials",
+  "license": "MIT",
   "scripts": {
     "test": "node test.js"
   },


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier. 